### PR TITLE
The format accepted for dates and time is strict on the RFC 3389 spec.

### DIFF
--- a/AdaptiveCards/authoring-cards/text-features.md
+++ b/AdaptiveCards/authoring-cards/text-features.md
@@ -82,7 +82,7 @@ Sometimes you won't know the timezone of the user receiving the card, so Adaptiv
     "body": [
         {
             "type": "TextBlock",
-            "text": "Your package will arrive on {{DATE(2017-02-14T06:00Z, SHORT)}} at {{TIME(2017-02-14T06:00Z)}}",
+            "text": "Your package will arrive on {{DATE(2017-02-14T06:00:00Z, SHORT)}} at {{TIME(2017-02-14T06:00:00Z)}}",
             "wrap": true
         }
     ]


### PR DESCRIPTION
While the Valid formats section is correct in specifying the seconds. The sample card was invalid.