### PR TITLE
Fixed broken link to sample HostConfig.json

### DIFF
--- a/AdaptiveCards/rendering-cards/host-config.md
+++ b/AdaptiveCards/rendering-cards/host-config.md
@@ -11,7 +11,7 @@ ms.topic: reference
 
 This allows properties which are platform agnostic to be shared among renderers on different platforms and devices. It also allows tooling to be created which gives you an idea of the look and feel that card would have for a given environment.
 
-See a sample [HostConfig.json](https://github.com/Microsoft/AdaptiveCards/blob/master/samples/v1.0/HostConfig/sample.json) to get a feeling for its contents.
+See a sample [HostConfig.json](https://github.com/Microsoft/AdaptiveCards/blob/master/samples/HostConfig/sample.json) to get a feeling for its contents.
 
 ---
 


### PR DESCRIPTION
I saw it was broken so tracked down the correct location.