### PR TITLE
Pass the AbsoluteUri to Process.Start rather than the URI

### DIFF
--- a/AdaptiveCards/sdk/rendering-cards/net-wpf/actions.md
+++ b/AdaptiveCards/sdk/rendering-cards/net-wpf/actions.md
@@ -20,7 +20,7 @@ private void MyActionHandler(RenderedAdaptiveCard sender, ActionEventArgs e)
 {
     if (e.Action is AdaptiveOpenUrlAction openUrlAction)
     {
-        Process.Start(openUrlAction.Url);
+        Process.Start(openUrlAction.Url.AbsoluteUri);
     }
     else if (e.Action is AdaptiveShowCardAction showCardAction)
     {


### PR DESCRIPTION
Pass a string to Process.Start so that it compiles