### PR TITLE
Update sample to use constructor that takes a version

### DIFF
--- a/AdaptiveCards/sdk/rendering-cards/net-wpf/render-a-card.md
+++ b/AdaptiveCards/sdk/rendering-cards/net-wpf/render-a-card.md
@@ -40,7 +40,7 @@ AdaptiveSchemaVersion schemaVersion = renderer.SupportedSchemaVersion;
 ```csharp
 // Build a simple card
 // In the real world this would probably be provided as JSON
-AdaptiveCard card = new AdaptiveCard()
+AdaptiveCard card = new AdaptiveCard("1.0")
 {
     Body = { new AdaptiveTextBlock() { Text = "Hello World" } }
 };


### PR DESCRIPTION
The no-argument version of the constructor is deprecated. Updated the sample to use the overload that takes the card version.