### PR TITLE
Fixing warnings caught in our files by the buildbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ obj/
 _site/
 .optemp/
 _themes*/
-
+.vs
 .openpublishing.buildcore.ps1

--- a/AdaptiveCards/authoring-cards/speech.md
+++ b/AdaptiveCards/authoring-cards/speech.md
@@ -13,7 +13,7 @@ The `speak` tag enables the adaptive card to be delivered to an environment wher
 
 ## Speak property
 To support speech we have a `speak` property which contains text to say to the user. The text can be annotated using speech synthesis markup language
-([SSML](https://msdn.microsoft.com/en-us/library/office/hh361578)). SSML controls the speed, tone, and inflection of the speech.  It even allows you to stream audio or a render a TTS audio stream from your own service, giving you a great deal of flexibility for customization.
+([SSML](https://msdn.microsoft.com/library/office/hh361578)). SSML controls the speed, tone, and inflection of the speech.  It even allows you to stream audio or a render a TTS audio stream from your own service, giving you a great deal of flexibility for customization.
 
 There are two patterns for speak property usage by a host application:
 

--- a/AdaptiveCards/getting-started/bots.md
+++ b/AdaptiveCards/getting-started/bots.md
@@ -110,8 +110,8 @@ If your bot is developed using .NET or NodeJS we have libraries to make building
 
 Platform|Install|Learn more
 --------|-------|----------
-.NET | `Install-Package AdaptiveCards -IncludePrerelease` | [Bot Framework .NET Docs](https://docs.microsoft.com/en-us/bot-framework/dotnet/bot-builder-dotnet-add-rich-card-attachments)
-NodeJS | `npm install adaptivecards` | [Bot Framework NodeJS Docs](https://docs.microsoft.com/en-us/bot-framework/nodejs/bot-builder-nodejs-send-rich-cards)
+.NET | `Install-Package AdaptiveCards -IncludePrerelease` | [Bot Framework .NET Docs](https://docs.microsoft.com/bot-framework/dotnet/bot-builder-dotnet-add-rich-card-attachments)
+NodeJS | `npm install adaptivecards` | [Bot Framework NodeJS Docs](https://docs.microsoft.com/bot-framework/nodejs/bot-builder-nodejs-send-rich-cards)
 
 
 ## Channel status

--- a/AdaptiveCards/getting-started/outlook.md
+++ b/AdaptiveCards/getting-started/outlook.md
@@ -21,6 +21,6 @@ You can now use Adaptive Cards to power your Outlook Actionable Messages, and cr
 
 # Ready to start?
 
-- Head over to https://docs.microsoft.com/en-us/outlook/actionable-messages/ which will guide you through the steps of creating your first Actionable Message scenario.
+- Head over to https://docs.microsoft.com/outlook/actionable-messages/ which will guide you through the steps of creating your first Actionable Message scenario.
 - Use the Actionable Message Card Playground tool to see card samples, create your own cards, send them to your own Office 365 account and see them in [Outlook for the Web](https://outlook.office.com).
 - Would you rather not write JSON manually? The [Adaptive Card Designer (preview)](https://acdesignerbeta.azurewebsites.net) lets you create Adaptive Cards without writing a single line of JSON!

--- a/AdaptiveCards/getting-started/outlook.md
+++ b/AdaptiveCards/getting-started/outlook.md
@@ -19,7 +19,7 @@ You can now use Adaptive Cards to power your Outlook Actionable Messages, and cr
 ![GitHub Actionable Message](media/outlook/Limeade.jpg)
 
 
-# Ready to start?
+## Ready to start?
 
 - Head over to https://docs.microsoft.com/outlook/actionable-messages/ which will guide you through the steps of creating your first Actionable Message scenario.
 - Use the Actionable Message Card Playground tool to see card samples, create your own cards, send them to your own Office 365 account and see them in [Outlook for the Web](https://outlook.office.com).

--- a/AdaptiveCards/getting-started/windows.md
+++ b/AdaptiveCards/getting-started/windows.md
@@ -16,7 +16,7 @@ The first Windows experience to supports Adaptive Cards is Timeline, a brand new
 
 ### UserActivity API
 
-The [`Windows.ApplicationModel.UserActivities.UserActivity`](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.useractivities.useractivity) API is what populates an Activity into Timeline.
+The [`Windows.ApplicationModel.UserActivities.UserActivity`](https://docs.microsoft.com/uwp/api/windows.applicationmodel.useractivities.useractivity) API is what populates an Activity into Timeline.
 
 The Adaptive Card will be supplied via the `Content` property of `VisualElement`, as seen below:
 
@@ -32,7 +32,7 @@ await userActivity.SaveAsync();
 
 There is a great 45-min learn module that covers these steps end-to-end.
 
-[Integrate adaptive cards into Windows 10 Timeline](https://docs.microsoft.com/en-us/learn/modules/integrate-app-into-windows-10-timeline/)
+[Integrate adaptive cards into Windows 10 Timeline](https://docs.microsoft.com/learn/modules/integrate-app-into-windows-10-timeline/)
 
 ### Learn more
 

--- a/AdaptiveCards/rendering-cards/speech.md
+++ b/AdaptiveCards/rendering-cards/speech.md
@@ -10,7 +10,7 @@ ms.topic: article
 
 To support speech adaptive Cards has the `speak` property which contains information on how a card should be read aloud to a user.
 
-The speech tag can be annotated using  [SSML markup](https://msdn.microsoft.com/en-us/library/office/hh361578(v=office.14).aspx). 
+The speech tag can be annotated using  [SSML markup](https://msdn.microsoft.com/library/office/hh361578(v=office.14).aspx). 
 SSML gives you the ability control the speed, tone, inflection of the speech.  It even allows you to stream audio or a render a TTS audio stream
 from your own service, giving you a great deal of customization.
 

--- a/AdaptiveCards/resources/partners.md
+++ b/AdaptiveCards/resources/partners.md
@@ -16,9 +16,9 @@ If you are interested in joining the Adaptive Cards ecosystem, please [reach out
 
 Platform | Description | Documentation | Version
 ---------|-------------|---------------|---------
-[Bot Framework Web Chat](https://github.com/Microsoft/BotFramework-WebChat)  | Embeddable web chat control for the Microsoft Bot Framework | [Get Started](https://docs.microsoft.com/en-us/adaptive-cards/get-started/bots) | 1.2 (Web Chat 4.6)
-[Cortana Skills](https://docs.microsoft.com/en-us/cortana/skills/adaptive-cards) | A virtual assistant for Windows 10 | [Get Started](https://docs.microsoft.com/en-us/adaptive-cards/get-started/bots) | 1.0
-[Windows Timeline](https://blogs.windows.com/windowsexperience/2017/12/19/announcing-windows-10-insider-preview-build-17063-pc/) | A new way to resume past activities you started on this PC, other Windows PCs, and iOS/Android devices. | [Get Started](https://docs.microsoft.com/en-us/adaptive-cards/get-started/windows) | 1.0
-[Outlook Actionable Messages](https://docs.microsoft.com/en-us/outlook/actionable-messages/)  | Attach an actionable message to email | [Get Started](https://docs.microsoft.com/en-us/outlook/actionable-messages/) | 1.0
-[Microsoft Teams](https://products.office.com/en-US/microsoft-teams/group-chat-software) | Platform that combines workplace chat, meetings, and notes | [Get Started](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/cards/cards-reference#adaptive-card) | 1.0
+[Bot Framework Web Chat](https://github.com/Microsoft/BotFramework-WebChat)  | Embeddable web chat control for the Microsoft Bot Framework | [Get Started](https://docs.microsoft.com/adaptive-cards/get-started/bots) | 1.2 (Web Chat 4.6)
+[Cortana Skills](https://docs.microsoft.com/cortana/skills/adaptive-cards) | A virtual assistant for Windows 10 | [Get Started](https://docs.microsoft.com/adaptive-cards/get-started/bots) | 1.0
+[Windows Timeline](https://blogs.windows.com/windowsexperience/2017/12/19/announcing-windows-10-insider-preview-build-17063-pc/) | A new way to resume past activities you started on this PC, other Windows PCs, and iOS/Android devices. | [Get Started](https://docs.microsoft.com/adaptive-cards/get-started/windows) | 1.0
+[Outlook Actionable Messages](https://docs.microsoft.com/outlook/actionable-messages/)  | Attach an actionable message to email | [Get Started](https://docs.microsoft.com/outlook/actionable-messages/) | 1.0
+[Microsoft Teams](https://products.office.com/microsoft-teams/group-chat-software) | Platform that combines workplace chat, meetings, and notes | [Get Started](https://docs.microsoft.com/microsoftteams/platform/concepts/cards/cards-reference#adaptive-card) | 1.0
 [Cisco WebEx Teams](https://www.webex.com/team-collaboration.html) | Webex Teams helps speed up projects, build better relationships, and solve business challenges. | [Get Started](https://developer.webex.com/docs/api/guides/cards) | 1.1

--- a/AdaptiveCards/templating/index.md
+++ b/AdaptiveCards/templating/index.md
@@ -175,7 +175,7 @@ The Templating SDKs make it possible to populate a template with real-data.
 Platform | Install | Documentation
 --- | --- | ---
 JavaScript | `npm install adaptivecards-templating` | [Documentation](https://www.npmjs.com/package/adaptivecards-templating)
-.NET | `nuget install AdaptiveCards.Templating` | [Documentation](https://docs.microsoft.com/en-us/adaptive-cards/templating/sdk#net)
+.NET | `nuget install AdaptiveCards.Templating` | [Documentation](https://docs.microsoft.com/adaptive-cards/templating/sdk#net)
 
 ### JavaScript Example
 


### PR DESCRIPTION
Fixing a bunch of localization and other warnings flagged and wrongly attributed to the [Xamarin.Android docs PR](https://github.com/MicrosoftDocs/AdaptiveCards/pull/241#user-content-10a14a89-3a11cd0b). (_Turns out that if you touch a specific folder, the bot will run these newer rules whether you actually made edits to the specific files themselves or not._)