### PR TITLE
C196067 - Converting plain-text link to MD syntax

### DIFF
--- a/AdaptiveCards/sdk/designer.md
+++ b/AdaptiveCards/sdk/designer.md
@@ -10,7 +10,7 @@ ms.topic: article
 
 The Adaptive Card Designer provides a rich, interactive design-time experience for authoring adaptive cards.
 
-Try it out at https://adaptivecards.io/designer
+Try it out at [https://adaptivecards.io/designer](https://adaptivecards.io/designer)
 
 ![Designer screenshot](../content/designer.png)
 


### PR DESCRIPTION
There are some languages that, based on linguistic grounds, changed the position of the links in comparison to their source content and placed them at the beginning of the string. This prevents their correct rendering on live pages. Kindly consider using MD hyperlink syntax structure \[..\]\(…\) 
Affected Line 13