### PR TITLE
Update renderer status page to reflect input validation

### DIFF
--- a/AdaptiveCards/rendering-cards/renderer-status.md
+++ b/AdaptiveCards/rendering-cards/renderer-status.md
@@ -34,7 +34,7 @@ The tables below show the current status of each renderer, based on their public
 |Spacing and Separator | ✅ | ✅ | ✅ | ✅ | ✅ |
 |[TextBlock DATE/TIME formatting](../authoring-cards/text-features.md#datetime-formatting-and-localization) | ✅ | ✅ | ✅ | ✅ | ✅ |
 |[TextBlock Markdown support](../authoring-cards/text-features.md#markdown) | ✅* | ✅ | ✅ | ✅ | ✅ |
-|Full Input support | ✅ | ✅ | ✅ | ✅ | ✅ |
+|Input Validation and Labels | ❌ | ✅ | ✅ | ✅ | ✅ |
 
 \* The HTML renderer doesn’t include built-in Markdown support in order to minimize the size of the library and to let consuming applications use their preferred Markdown processor. The HTML renderer will however automatically use Markdown-It if it is loaded.
 
@@ -45,7 +45,7 @@ The tables below show the current status of each renderer, based on their public
 |Override Element Renderer | ✅ | ✅ | ✅ | ✅ | ✅ |
 |Add new Element Renderer | ✅ | ✅ | ✅ | ✅ | ✅ |
 |Remove Element Renderer | ✅ | ✅ | ✅ | ✅ | ✅ |
-|[Override/add/remove Action Renderer](https://github.com/Microsoft/AdaptiveCards/issues/1671) | ✅ | ✅ | ❌ | ✅ | ✅ |
+|[Override/add/remove Action Renderer](https://github.com/Microsoft/AdaptiveCards/issues/1671) | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ### Actions
 

--- a/AdaptiveCards/rendering-cards/renderer-status.md
+++ b/AdaptiveCards/rendering-cards/renderer-status.md
@@ -33,7 +33,7 @@ The tables below show the current status of each renderer, based on their public
 |--- | --- | --- | --- | --- | --- | --- |
 |Spacing and Separator | ✅ | ✅ | ✅ | ✅ | ✅ |
 |[TextBlock DATE/TIME formatting](../authoring-cards/text-features.md#datetime-formatting-and-localization) | ✅ | ✅ | ✅ | ✅ | ✅ |
-|[TextBlock Markdown support](../authoring-cards/text-features.md#Markdown-(Commonmark-subset)) | ✅* | ✅ | ✅ | ✅ | ✅ |
+|[TextBlock Markdown support](../authoring-cards/text-features.md#Markdown-Commonmark-subset) | ✅* | ✅ | ✅ | ✅ | ✅ |
 |Input Validation and Labels | ❌ | ✅ | ✅ | ✅ | ✅ |
 
 \* The HTML renderer doesn’t include built-in Markdown support in order to minimize the size of the library and to let consuming applications use their preferred Markdown processor. The HTML renderer will however automatically use Markdown-It if it is loaded.

--- a/AdaptiveCards/rendering-cards/renderer-status.md
+++ b/AdaptiveCards/rendering-cards/renderer-status.md
@@ -33,7 +33,7 @@ The tables below show the current status of each renderer, based on their public
 |--- | --- | --- | --- | --- | --- | --- |
 |Spacing and Separator | ✅ | ✅ | ✅ | ✅ | ✅ |
 |[TextBlock DATE/TIME formatting](../authoring-cards/text-features.md#datetime-formatting-and-localization) | ✅ | ✅ | ✅ | ✅ | ✅ |
-|[TextBlock Markdown support](../authoring-cards/text-features.md#Markdown-Commonmark-subset) | ✅* | ✅ | ✅ | ✅ | ✅ |
+|[TextBlock Markdown support](../authoring-cards/text-features.md#markdown-commonmark-subset) | ✅* | ✅ | ✅ | ✅ | ✅ |
 |Input Validation and Labels | ❌ | ✅ | ✅ | ✅ | ✅ |
 
 \* The HTML renderer doesn’t include built-in Markdown support in order to minimize the size of the library and to let consuming applications use their preferred Markdown processor. The HTML renderer will however automatically use Markdown-It if it is loaded.

--- a/AdaptiveCards/rendering-cards/renderer-status.md
+++ b/AdaptiveCards/rendering-cards/renderer-status.md
@@ -33,8 +33,8 @@ The tables below show the current status of each renderer, based on their public
 |--- | --- | --- | --- | --- | --- | --- |
 |Spacing and Separator | ✅ | ✅ | ✅ | ✅ | ✅ |
 |[TextBlock DATE/TIME formatting](../authoring-cards/text-features.md#datetime-formatting-and-localization) | ✅ | ✅ | ✅ | ✅ | ✅ |
-|[TextBlock Markdown support](../authoring-cards/text-features.md#markdown) | ✅* | ✅ | ✅ | ✅ | ✅ |
-|Input Validation and Labels | ❌ | ✅ | ✅ | ✅ | ✅ |
+|[TextBlock Markdown support](../authoring-cards/text-features.md#Markdown-(Commonmark-subset)) | ✅* | ✅ | ✅ | ✅ | ✅ |
+|Input Validation and Labels | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 \* The HTML renderer doesn’t include built-in Markdown support in order to minimize the size of the library and to let consuming applications use their preferred Markdown processor. The HTML renderer will however automatically use Markdown-It if it is loaded.
 

--- a/AdaptiveCards/rendering-cards/renderer-status.md
+++ b/AdaptiveCards/rendering-cards/renderer-status.md
@@ -34,7 +34,7 @@ The tables below show the current status of each renderer, based on their public
 |Spacing and Separator | ✅ | ✅ | ✅ | ✅ | ✅ |
 |[TextBlock DATE/TIME formatting](../authoring-cards/text-features.md#datetime-formatting-and-localization) | ✅ | ✅ | ✅ | ✅ | ✅ |
 |[TextBlock Markdown support](../authoring-cards/text-features.md#Markdown-(Commonmark-subset)) | ✅* | ✅ | ✅ | ✅ | ✅ |
-|Input Validation and Labels | ✅ | ✅ | ✅ | ✅ | ✅ |
+|Input Validation and Labels | ❌ | ✅ | ✅ | ✅ | ✅ |
 
 \* The HTML renderer doesn’t include built-in Markdown support in order to minimize the size of the library and to let consuming applications use their preferred Markdown processor. The HTML renderer will however automatically use Markdown-It if it is loaded.
 


### PR DESCRIPTION
Updated the "Full Input Support" row to reflect that .NET HTML doesn't have label/validation support. Also updated the UWP custom action rendering checkbox to reflect that that support now exists.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/MicrosoftDocs/AdaptiveCards/pull/321)