### PR TITLE
Updating the link to AEL prebuilt Expressions

### DIFF
--- a/AdaptiveCards/templating/language.md
+++ b/AdaptiveCards/templating/language.md
@@ -255,7 +255,7 @@ No templating language is complete without a rich suite of helper functions. Ada
 
 **This is just a small sampling of the built-in functions.**
 
-Check out the full list of [Adaptive Expression Language Pre-built functions](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-adaptive-expressions?view=azure-bot-service-4.0).
+Check out the full list of [Adaptive Expression Language Pre-built functions](https://docs.microsoft.com/en-us/azure/bot-service/adaptive-expressions/adaptive-expressions-prebuilt-functions?view=azure-bot-service-4.0).
 
 ### Conditional evaluation
 


### PR DESCRIPTION
Pointing to the more complete reference page vs the concepts page that didnt include all the expressions it supported.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/MicrosoftDocs/AdaptiveCards/pull/324)