### PR TITLE
Spelling mistake langauge (Typo)

### DIFF
--- a/AdaptiveCards/templating/language.md
+++ b/AdaptiveCards/templating/language.md
@@ -8,7 +8,7 @@ ms.topic: article
 
 # Adaptive Cards Template Language
 
-Templating enables the separation of **data** from **layout** in your Adaptive Card. The template langauge is the syntax used to author a template. 
+Templating enables the separation of **data** from **layout** in your Adaptive Card. The template language is the syntax used to author a template. 
 
 > Please read this for an [overview of Adaptive Card Templating](index.md)
 


### PR DESCRIPTION
There is minor correction into documentation.  Spelling "langauge" is not correct. It added corrected word i.e. language. Kindly review and update. 
Thanks.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/MicrosoftDocs/AdaptiveCards/pull/340)