### PR TITLE
Linkfix: Adaptive Cards (2021-06)

### DIFF
--- a/AdaptiveCards/authoring-cards/universal-action-model.md
+++ b/AdaptiveCards/authoring-cards/universal-action-model.md
@@ -21,7 +21,7 @@ As Adaptive Cards grew in popularity, different hosts started supporting differe
 
 For more information about Actionable Messages in Outlook, please refer to the [Actionable Message documentation](/outlook/actionable-messages/send-via-email)
 
-For details on various scenarios possible with Universal Actions in Teams, please refer to [Teams cards reference](https://docs.microsoft.com/microsoftteams/platform/task-modules-and-cards/cards/universal-actions-for-adaptive-cards/overview).
+For details on various scenarios possible with Universal Actions in Teams, please refer to [Teams cards reference](/microsoftteams/platform/task-modules-and-cards/cards/universal-actions-for-adaptive-cards/overview).
 
 Before `Action.Execute` |  With `Action.Execute`
 :-------------------------:|:-------------------------:
@@ -111,7 +111,7 @@ To allow an Adaptive Card to automatically refresh, define its `refresh` propert
 | Property | Type | Required | Description 
 | -------- | ---- | -------- | ----------- 
 | **action** | `"Action.Execute"` | Yes | Must be an action instance of type `"Action.Execute"`. |
-| **userIds** | `Array<string>` | Yes | An array of `MRI`s of users for whom Auto Refresh must be enabled.<br><br>**IMPORTANT:** If the `userIds` list property isn't included in the `refresh` section of the card, the card will NOT automatically refresh on display. Instead, a button will be presented to the user to allow them to manually refresh. The reason for this is chats/channels in Teams can include a large number of members; if many members are all viewing the channel at the same time, an unconditional automatic refresh would result in many concurrent calls to the bot, which would not scale. To alleviate the potential scale problem, the `userIds` property should always be included to identify which users should get an automatic refresh, with a maximum of **60** user IDs currently being allowed.  See [userIds in refresh](https://docs.microsoft.com//microsoftteams/platform/task-modules-and-cards/cards/universal-actions-for-adaptive-cards/work-with-universal-actions-for-adaptive-cards#user-ids-in-refresh) for more details.<br><br>Note that the `userIds` property is ignored in Outlook, and the `refresh` property is always automatically honored. There is no scale issue in Outlook because users will typically view the card at different times.|
+| **userIds** | `Array<string>` | Yes | An array of `MRI`s of users for whom Auto Refresh must be enabled.<br><br>**IMPORTANT:** If the `userIds` list property isn't included in the `refresh` section of the card, the card will NOT automatically refresh on display. Instead, a button will be presented to the user to allow them to manually refresh. The reason for this is chats/channels in Teams can include a large number of members; if many members are all viewing the channel at the same time, an unconditional automatic refresh would result in many concurrent calls to the bot, which would not scale. To alleviate the potential scale problem, the `userIds` property should always be included to identify which users should get an automatic refresh, with a maximum of **60** user IDs currently being allowed.  See [userIds in refresh](//microsoftteams/platform/task-modules-and-cards/cards/universal-actions-for-adaptive-cards/work-with-universal-actions-for-adaptive-cards#user-ids-in-refresh) for more details.<br><br>Note that the `userIds` property is ignored in Outlook, and the `refresh` property is always automatically honored. There is no scale issue in Outlook because users will typically view the card at different times.|
 
 **Sample JSON**
 ```JSON
@@ -290,6 +290,6 @@ In the below example, note the `version` property of the card is set to `1.2` an
 ```
 
 ## References
-- [Universal Action Model Teams Documentation](https://docs.microsoft.com/microsoftteams/platform/task-modules-and-cards/cards/universal-actions-for-adaptive-cards/overview)
+- [Universal Action Model Teams Documentation](/microsoftteams/platform/task-modules-and-cards/cards/universal-actions-for-adaptive-cards/overview)
 - [Adaptive Cards @ Microsoft Build 2020](https://youtu.be/hEBhwB72Qn4?t=1393)
 - [Adaptive Cards @ Ignite 2020](https://techcommunity.microsoft.com/t5/video-hub/elevate-user-experiences-with-teams-and-adaptive-cards/m-p/1689460)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/MicrosoftDocs/AdaptiveCards/pull/401)