### PR TITLE
Linkfix: Adaptive Cards (2021-09)

### DIFF
--- a/AdaptiveCards/rendering-cards/actions.md
+++ b/AdaptiveCards/rendering-cards/actions.md
@@ -14,4 +14,4 @@ By default, the actions will render as buttons on the card, but it's up to your 
 * **Action.Submit** - take the result of the submit and send it to the source. How you send it to the source of the card is entirely up to you.
 * **Action.ShowCard** - invokes a dialog and renders the sub-card into that dialog. Note that you only need to handle this if `ShowCardActionMode` is set to `popup`.
 * **Action.ToggleVisibility** - shows or hides one or more elements in the card.
-* **Action.Execute** - gathers input fields, merges with optional data field, and sends an event to the client. Learn more about Action.Execute in our [Universal Action Model](https://docs.microsoft.com/adaptive-cards/authoring-cards/universal-action-model) section.
+* **Action.Execute** - gathers input fields, merges with optional data field, and sends an event to the client. Learn more about Action.Execute in our [Universal Action Model](../authoring-cards/universal-action-model.md) section.


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```
