### PR TITLE
[BrokenLinksH2] fixing broken link

### DIFF
--- a/AdaptiveCards/sdk/rendering-cards/react-native/getting-started.md
+++ b/AdaptiveCards/sdk/rendering-cards/react-native/getting-started.md
@@ -9,11 +9,11 @@ ms.topic: article
 
 # ReactNative Renderer
 
-A [community-supported](https://github.com/microsoft/AdaptiveCards/blob/main/SUPPORT.MD) ReactNative renderer for Adaptive Cards, maintained by [BigThinkCode](https://www.bigthinkcode.com).
+A [community-supported](/lifecycle/end-of-support/end-of-support-2020) ReactNative renderer for Adaptive Cards, maintained by [BigThinkCode](https://www.bigthinkcode.com).
 
 > [!IMPORTANT]
 >
-> **Community Support Only**. This renderer is in active development but is maintained outside of Microsoft. **As such, we cannot guarantee any SLA for this SDK**. Please see our [Support policy](https://github.com/microsoft/AdaptiveCards/blob/main/SUPPORT.MD) for more details. 
+> **Community Support Only**. This renderer is in active development but is maintained outside of Microsoft. **As such, we cannot guarantee any SLA for this SDK**. Please see our [Support policy](/lifecycle/end-of-support/end-of-support-2020) for more details. 
 >
 
 ## Getting started


### PR DESCRIPTION
**Global effort to fix broken links**

@matthidinger
The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. Please review within five business days and merge, or comment in the PR with any changes you'd like to see. Thanks!

