### PR TITLE
Update Microsoft Teams schema version to 1.5

### DIFF
--- a/AdaptiveCards/resources/partners.md
+++ b/AdaptiveCards/resources/partners.md
@@ -19,7 +19,7 @@ Platform | Description | Documentation | Schema Version
 ---------|-------------|---------------|---------
 [Bot Framework Web Chat](https://github.com/Microsoft/BotFramework-WebChat)  | Embeddable web chat control for the Microsoft Bot Framework | [Get Started](../getting-started/bots.md) | 1.5 (Web Chat 4.15.6)
 [Outlook Actionable Messages](/outlook/actionable-messages/)  | Attach an actionable message to email | [Get Started](/outlook/actionable-messages/) | 1.0
-[Microsoft Teams](https://products.office.com/microsoft-teams/group-chat-software) | Platform that combines workplace chat, meetings, and notes | [Get Started](/microsoftteams/platform/concepts/cards/cards-reference#adaptive-card) | 1.4
+[Microsoft Teams](https://products.office.com/microsoft-teams/group-chat-software) | Platform that combines workplace chat, meetings, and notes | [Get Started](/microsoftteams/platform/concepts/cards/cards-reference#adaptive-card) | 1.5
 [Cortana Skills](/cortana/skills/adaptive-cards) | A virtual assistant for Windows 10 | [Get Started](../getting-started/bots.md) | 1.0
 [Windows Timeline](https://blogs.windows.com/windowsexperience/2017/12/19/announcing-windows-10-insider-preview-build-17063-pc/) | A new way to resume past activities you started on this PC, other Windows PCs, and iOS/Android devices. | [Get Started](../getting-started/windows.md) | 1.0
 [Cisco WebEx Teams](https://www.webex.com/team-collaboration.html) | Webex Teams helps speed up projects, build better relationships, and solve business challenges. | [Get Started](https://developer.webex.com/docs/api/guides/cards) | 1.2


### PR DESCRIPTION
Microsoft teams supports schema v1.5

Source: https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#support-for-adaptive-cards 

![image](https://user-images.githubusercontent.com/2804423/233487540-eeb0154a-236b-4b0e-b081-85062216de88.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/MicrosoftDocs/AdaptiveCards/pull/505)