### PR TITLE
Update to Web Chat 4.18.0 with AC schema 1.6

### DIFF
--- a/AdaptiveCards/resources/partners.md
+++ b/AdaptiveCards/resources/partners.md
@@ -17,7 +17,7 @@ If you are interested in joining the Adaptive Cards ecosystem, please [reach out
 
 Platform | Description | Documentation | Schema Version
 ---------|-------------|---------------|---------
-[Bot Framework Web Chat](https://github.com/Microsoft/BotFramework-WebChat)  | Embeddable web chat control for the Microsoft Bot Framework | [Get Started](../getting-started/bots.md) | 1.5 (Web Chat 4.15.8)
+[Bot Framework Web Chat](https://github.com/Microsoft/BotFramework-WebChat)  | Embeddable web chat control for the Microsoft Bot Framework | [Get Started](../getting-started/bots.md) | 1.6 (Web Chat 4.18.0)
 [Outlook Actionable Messages](/outlook/actionable-messages/)  | Attach an actionable message to email | [Get Started](/outlook/actionable-messages/) | 1.0
 [Microsoft Teams](https://products.office.com/microsoft-teams/group-chat-software) | Platform that combines workplace chat, meetings, and notes | [Get Started](/microsoftteams/platform/concepts/cards/cards-reference#adaptive-card) | 1.5
 [Cortana Skills](/cortana/skills/adaptive-cards) | A virtual assistant for Windows 10 | [Get Started](../getting-started/bots.md) | 1.0


### PR DESCRIPTION
Release of Web Chat can be found at https://github.com/microsoft/BotFramework-WebChat/issues/5239.